### PR TITLE
Improve performance by avoiding indexing

### DIFF
--- a/clear_html/formatted_text/main.py
+++ b/clear_html/formatted_text/main.py
@@ -111,20 +111,17 @@ def paragraphy(doc: HtmlElement):
     when possible. Document is updated inline.
     """
     # Let's detect the sequences of consecutive br
-    children = list(doc)
-    n_children = len(children)
+    n_children = len(doc)
     br_sequences: List[Tuple[int, int]] = []
     start, end = None, None
-    for idx, child in enumerate(children):
+    for idx, child in enumerate(doc):
         if child.tag == "br":
-            if idx == 0 or children[idx - 1].tag != "br" or has_tail(children[idx - 1]):
+            prev_child = child.getprevious()
+            if prev_child is None or prev_child.tag != "br" or has_tail(prev_child):
                 # A br without previous consecutive br was found
                 start = idx
-            if (
-                idx == n_children - 1
-                or children[idx + 1].tag != "br"
-                or has_tail(child)
-            ):
+            next_child = child.getnext()
+            if next_child is None or next_child.tag != "br" or has_tail(child):
                 # A br without next consecutive br was found
                 end = idx
                 if start == end:
@@ -142,7 +139,7 @@ def paragraphy(doc: HtmlElement):
 
     # Let's split the node into different paragraphs
     br_sequences.append((n_children, n_children))  # To get last chunk included
-    children = [copy.copy(c) for c in children]
+    children = [copy.copy(c) for c in doc]
     del doc[:n_children]
 
     last_inline_chunk: List[HtmlElement] = []

--- a/clear_html/formatted_text/main.py
+++ b/clear_html/formatted_text/main.py
@@ -120,7 +120,11 @@ def paragraphy(doc: HtmlElement):
             if idx == 0 or children[idx - 1].tag != "br" or has_tail(children[idx - 1]):
                 # A br without previous consecutive br was found
                 start = idx
-            if idx == n_children - 1 or children[idx + 1].tag != "br" or has_tail(child):
+            if (
+                idx == n_children - 1
+                or children[idx + 1].tag != "br"
+                or has_tail(child)
+            ):
                 # A br without next consecutive br was found
                 end = idx
                 if start == end:

--- a/clear_html/formatted_text/main.py
+++ b/clear_html/formatted_text/main.py
@@ -111,15 +111,16 @@ def paragraphy(doc: HtmlElement):
     when possible. Document is updated inline.
     """
     # Let's detect the sequences of consecutive br
-    n_children = len(doc)
+    children = list(doc)
+    n_children = len(children)
     br_sequences: List[Tuple[int, int]] = []
     start, end = None, None
-    for idx, child in enumerate(doc):
+    for idx, child in enumerate(children):
         if child.tag == "br":
-            if idx == 0 or doc[idx - 1].tag != "br" or has_tail(doc[idx - 1]):
+            if idx == 0 or children[idx - 1].tag != "br" or has_tail(children[idx - 1]):
                 # A br without previous consecutive br was found
                 start = idx
-            if idx == n_children - 1 or doc[idx + 1].tag != "br" or has_tail(child):
+            if idx == n_children - 1 or children[idx + 1].tag != "br" or has_tail(child):
                 # A br without next consecutive br was found
                 end = idx
                 if start == end:
@@ -137,7 +138,7 @@ def paragraphy(doc: HtmlElement):
 
     # Let's split the node into different paragraphs
     br_sequences.append((n_children, n_children))  # To get last chunk included
-    children = [copy.copy(c) for c in doc]
+    children = [copy.copy(c) for c in children]
     del doc[:n_children]
 
     last_inline_chunk: List[HtmlElement] = []

--- a/clear_html/formatted_text/main.py
+++ b/clear_html/formatted_text/main.py
@@ -27,6 +27,7 @@ from clear_html.formatted_text.figures import (
 from clear_html.formatted_text.headings import normalize_headings_level
 from clear_html.formatted_text.utils import (
     clean_incomplete_structures,
+    double_br,
     kill_tag_content,
     remove_empty_tags,
     set_article_tag_as_root,
@@ -116,12 +117,10 @@ def paragraphy(doc: HtmlElement):
     start, end = None, None
     for idx, child in enumerate(doc):
         if child.tag == "br":
-            prev_child = child.getprevious()
-            if prev_child is None or prev_child.tag != "br" or has_tail(prev_child):
+            if not double_br(child.getprevious()):
                 # A br without previous consecutive br was found
                 start = idx
-            next_child = child.getnext()
-            if next_child is None or next_child.tag != "br" or has_tail(child):
+            if not double_br(child):
                 # A br without next consecutive br was found
                 end = idx
                 if start == end:

--- a/clear_html/formatted_text/utils.py
+++ b/clear_html/formatted_text/utils.py
@@ -163,12 +163,12 @@ def drop_tag_preserve_spacing(doc: HtmlElement, preserve_content=True):
         prev_is_inline = (
             doc_prev is not None
             and doc_prev.tag in PHRASING_CONTENT
-            and not _double_br(doc_prev.getprevious())
+            and not double_br(doc_prev.getprevious())
         )
         after_is_inline = (
             doc_next is not None
             and doc_next.tag in PHRASING_CONTENT
-            and not _double_br(doc_next)
+            and not double_br(doc_next)
         )
 
         has_text_prev = bool(prev_text(doc).strip()) or prev_is_inline
@@ -192,7 +192,7 @@ def drop_tag_preserve_spacing(doc: HtmlElement, preserve_content=True):
         doc.drop_tree()
 
 
-def _double_br(doc: Optional[HtmlElement]):
+def double_br(doc: Optional[HtmlElement]):
     """True if doc and next element are "br" tags without text in between."""
     if doc is None or doc.tag != "br":
         return False

--- a/clear_html/lxml_utils.py
+++ b/clear_html/lxml_utils.py
@@ -83,12 +83,16 @@ def prev_text(doc: HtmlElement) -> str:
     parent = doc.getparent()
     if parent is None:
         return ""
-    idx = parent.index(doc)
-    if idx == 0:
-        text = parent.text
+    previous = doc.getprevious()
+    if previous is None:
+        parent = doc.getparent()
+        if parent is None:
+            text = ""
+        else:
+            text = parent.text or ""
     else:
-        text = parent[idx - 1].tail
-    return text or ""
+        text = previous.tail or ""
+    return text
 
 
 def iter_deep_first_post_order(doc: HtmlElement) -> Generator[HtmlElement, Any, None]:


### PR DESCRIPTION
A lot of the code is written with the assumption that doing `element[idx]` is fast, but in fact it is slow because

> The data structure used by libxml2 is a linked tree, and thus, a linked list of children

(see https://lxml.de/performance.html#child-access), so in a lot of places we have quadratic performance if not worse, and the number of children in some documents can be large (I've seen 20k in one of slow examples).

This PR fixes two cases which I noticed when profiling. From looking at the code it seems that there are more places that do indexing, but they didn't show up on examples I checked and they look like they require a bigger refactoring (e.g. with figure caption processing), and it's not clear if performance would be much improved. In two cases I checked we took 30 -- 40 seconds to execute some operations, that went to almost instant in one case and to 6 s in the other case (all spent in lxml code which drops the tag).