### PR TITLE
improve cleaner memory usage

### DIFF
--- a/clear_html/formatted_text/cleaner.py
+++ b/clear_html/formatted_text/cleaner.py
@@ -77,7 +77,11 @@ class BodyCleaner(Cleaner):
                     el = to_remove.pop(-1)
                     el.tag = "div"
                     el.attrib.clear()
-                for el in to_remove:
+                # don't hold removed elements in memory to reduce memory usage,
+                # as they are being merged into parent elements
+                to_remove.reverse()
+                while to_remove:
+                    el = to_remove.pop()
                     drop_tag_preserve_spacing(el)
 
     def allow_element(self, el):

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ commands = mypy {posargs:clear_html tests}
 [testenv:twinecheck]
 basepython = python3
 deps =
-    twine==4.0.2
-    build==0.10.0
+    twine==5.1.1
+    build==1.2.1
 commands =
     python -m build --sdist
     twine check dist/*


### PR DESCRIPTION
don't hold removed elements in memory to reduce memory usage, as they are being merged into parent elements and element text is growing. On some pathalogical HTMLs (a few MB in size) this leads to hundreds of MB of a difference.